### PR TITLE
Update wrangler to remove terminal warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240529.0",
     "drizzle-kit": "^0.23.0",
-    "wrangler": "^3.57.2"
+    "wrangler": "^3.67.0"
   },
   "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,7 +304,7 @@ app.get(
               ws.send(JSON.stringify({ type: 'GEESE', payload: geese }))
             })
             break
-          case 'CREATE_GOOSE':
+          case 'CREATE_GOOSE': {
             const { name, isFlockLeader, programmingLanguage, motivations, location } = payload
             const description = `A person named ${name} who talks like a Goose`
 
@@ -323,6 +323,7 @@ app.get(
                 ws.send(JSON.stringify({ type: 'NEW_GOOSE', payload: newGoose[0] }))
               })
             break
+          }
           // ... (handle other message types)
           default:
             break

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,10 +1223,10 @@ workerd@1.20240718.0:
     "@cloudflare/workerd-linux-arm64" "1.20240718.0"
     "@cloudflare/workerd-windows-64" "1.20240718.0"
 
-wrangler@^3.57.2:
-  version "3.65.1"
-  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.65.1.tgz#493bd92b504f9f056cd57bbe2d430797600c914b"
-  integrity sha512-Z5NyrbpGMQCpim/6VnI1im0/Weh5+CU1sdep1JbfFxHjn/Jt9K+MeUq+kCns5ubkkdRx2EYsusB/JKyX2JdJ4w==
+wrangler@^3.67.0:
+  version "3.67.0"
+  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.67.0.tgz#884dd1030772e5dc0c06da1dd69e15682ce4e170"
+  integrity sha512-elun6p9rAmGr/CtnCixhUXWeKT+LnFbHDsLLizgAlFJbsgCPV/O1if7uMjTGD/fUJNXrwbTVRpxvInz5X9gE2Q==
   dependencies:
     "@cloudflare/kv-asset-handler" "0.3.4"
     "@esbuild-plugins/node-globals-polyfill" "^0.2.3"
@@ -1243,6 +1243,7 @@ wrangler@^3.57.2:
     selfsigned "^2.0.1"
     source-map "^0.6.1"
     unenv "npm:unenv-nightly@1.10.0-1717606461.a117952"
+    workerd "1.20240718.0"
     xxhash-wasm "^1.0.1"
   optionalDependencies:
     fsevents "~2.3.2"


### PR DESCRIPTION
If you `yarn dev` on main, you get a warning that tells you to update wrangler.

This PR updates wrangler.

Also did a tiny mod to a switch case 